### PR TITLE
Fix transition dom null issue

### DIFF
--- a/src/core/componentStructure.js
+++ b/src/core/componentStructure.js
@@ -1,4 +1,7 @@
-const getHtmlElementFromNode = ({ el }) => el;
+const getHtmlElementFromNode = (node) => {
+  const el = node.el || (Array.isArray(node.children) && node.children[0].el.parentNode);
+  return el || {};
+};
 const addContext = (domElement, context) =>
   (domElement.__draggable_context = context);
 const getContext = domElement => domElement.__draggable_context;


### PR DESCRIPTION
When using 'tag="transition-group"' and 'item-key', a "domElement is null" error occurs since tranistion element is not available in latest vue.

Related issues:
issue#149
issue#138
issue#140

This fix is from pr#145: https://github.com/SortableJS/vue.draggable.next/pull/145/files